### PR TITLE
refactor(host): add optional topic parameter to superclass publish method

### DIFF
--- a/buttermilk/_core/agent.py
+++ b/buttermilk/_core/agent.py
@@ -749,13 +749,21 @@ class Agent(RoutedAgent):
 
     # --- Helper Methods ---
 
-    async def _publish(self, message: Any, highlight: bool = False) -> None:
-        """Publish a message to the group chat."""
-        await self.publish_message(message, topic_id=self._topic_id)
+    async def _publish(self, message: Any, highlight: bool = False, topic_id: TopicId | None = None) -> None:
+        """Publish a message to the group chat or a specific topic.
+        
+        Args:
+            message: The message to publish.
+            highlight: Whether to highlight the message in logs.
+            topic_id: Optional specific topic to publish to. Defaults to self._topic_id.
+        """
+        # Use provided topic_id or fall back to the agent's default topic
+        target_topic = topic_id or self._topic_id
+        await self.publish_message(message, topic_id=target_topic)
         if not highlight and isinstance(message, (AgentTrace, AgentOutput)):
             highlight = True  # Highlight traces and outputs by default
         if highlight:
-            logger.highlight(f"Agent {self.agent_name} published {type(message).__name__} message to topic {self._topic_id}")
+            logger.highlight(f"Agent {self.agent_name} published {type(message).__name__} message to topic {target_topic}")
 
     async def _add_state_to_input(self, inputs: AgentInput) -> AgentInput:
         """Augments an incoming `AgentInput` message with the agent's internal state.

--- a/buttermilk/agents/flowcontrol/host.py
+++ b/buttermilk/agents/flowcontrol/host.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from collections.abc import AsyncGenerator
 from typing import Any  # Import Dict
 
-from autogen_core import CancellationToken, MessageContext, message_handler
+from autogen_core import CancellationToken, DefaultTopicId, MessageContext, message_handler
 from autogen_core.models import AssistantMessage, UserMessage
 from autogen_core.tools import (
     Tool,
@@ -19,6 +19,7 @@ from buttermilk._core.contract import (
     AgentTrace,
     ConductorRequest,
     ErrorEvent,
+    FlowEvent,
     FlowProgressUpdate,
     ManagerMessage,
     StepRequest,
@@ -614,6 +615,14 @@ class HostAgent(Agent):
                 # This event is used in the wait_for predicate.
                 self._step_starting.set()
                 logger.debug(f"Host set _step_starting event for role: {step.role}")
+                
+                # Send a FlowEvent to the main topic to notify UI about the step starting
+                flow_event = FlowEvent(
+                    source=self.agent_id,
+                    content=f"Starting {step.role} step: {self._participants.get(step.role, step.role)}"
+                )
+                await self._publish(flow_event)  # This goes to the main topic
+                
             elif step.role == MANAGER:
                 # MANAGER steps don't spawn trackable worker tasks, so don't set _step_starting
                 # Convert StepRequest to UIMessage for frontend display
@@ -626,7 +635,9 @@ class HostAgent(Agent):
             else:
                 logger.warning(f"Host executing step for unknown participant role: {step.role}")
 
-            await self._publish(step)
+            # Route StepRequest to role-specific topic
+            role_topic = DefaultTopicId(type=step.role)
+            await self._publish(step, topic_id=role_topic)
 
     async def _process(
         self,
@@ -680,7 +691,9 @@ class HostAgent(Agent):
                 else:
                     # If human_in_loop is False, we send the step request directly
                     logger.info(f"Host {self.agent_name} routing tool call to agent {role_part}: {step_request}")
-                    await self._publish(step_request)
+                    # Route to role-specific topic
+                    role_topic = DefaultTopicId(type=role_part)
+                    await self._publish(step_request, topic_id=role_topic)
 
     def _describe_tool_call(self, tool_name: str, arguments: dict) -> str:
         """Generate a concise description of a tool call.

--- a/tests/test_host_topic_routing.py
+++ b/tests/test_host_topic_routing.py
@@ -1,0 +1,190 @@
+"""Tests for HostAgent topic routing functionality."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from autogen_core import DefaultTopicId
+
+from buttermilk._core.contract import (
+    ConductorRequest,
+    FlowEvent,
+    StepRequest,
+    UIMessage,
+)
+from buttermilk.agents.flowcontrol.host import HostAgent
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture
+def mock_host_agent():
+    """Create a mocked HostAgent for testing."""
+    agent = HostAgent(
+        agent_id="test-host",
+        agent_name="TestHost",
+        role="HOST",
+        description="Test host agent",
+        parameters={"human_in_loop": False}
+    )
+    # Mock the publish_message method to track calls
+    agent.publish_message = AsyncMock()
+    agent._topic_id = DefaultTopicId(type="main-topic")
+    agent._participants = {
+        "RESEARCHER": "Research agent",
+        "WRITER": "Writing agent",
+        "MANAGER": "Manager agent"
+    }
+    return agent
+
+
+class TestHostTopicRouting:
+    """Test cases for host agent topic routing."""
+
+    @pytest.mark.asyncio
+    async def test_step_request_routes_to_role_topic(self, mock_host_agent):
+        """Test that StepRequest messages are routed to role-specific topics."""
+        # Create a StepRequest
+        step = StepRequest(
+            role="RESEARCHER",
+            content="Execute researcher step",
+            inputs={"query": "test query"}
+        )
+        
+        # Execute the step
+        await mock_host_agent._execute_step(step)
+        
+        # Verify two publish calls were made
+        assert mock_host_agent.publish_message.call_count == 2
+        
+        # First call should be FlowEvent to main topic
+        first_call = mock_host_agent.publish_message.call_args_list[0]
+        assert isinstance(first_call[0][0], FlowEvent)
+        assert first_call[1]["topic_id"] == mock_host_agent._topic_id
+        
+        # Second call should be StepRequest to role-specific topic
+        second_call = mock_host_agent.publish_message.call_args_list[1]
+        assert isinstance(second_call[0][0], StepRequest)
+        assert second_call[1]["topic_id"] == DefaultTopicId(type="RESEARCHER")
+
+    @pytest.mark.asyncio
+    async def test_flow_event_sent_before_step_request(self, mock_host_agent):
+        """Test that FlowEvent is sent to main topic before StepRequest."""
+        step = StepRequest(
+            role="WRITER",
+            content="Execute writer step"
+        )
+        
+        await mock_host_agent._execute_step(step)
+        
+        # Verify FlowEvent content
+        flow_event = mock_host_agent.publish_message.call_args_list[0][0][0]
+        assert isinstance(flow_event, FlowEvent)
+        assert flow_event.source == mock_host_agent.agent_id
+        assert "Starting WRITER step" in flow_event.content
+        assert "Writing agent" in flow_event.content
+
+    @pytest.mark.asyncio
+    async def test_manager_step_sends_ui_message_only(self, mock_host_agent):
+        """Test that MANAGER steps only send UIMessage to main topic."""
+        step = StepRequest(
+            role="MANAGER",
+            content="What would you like to do next?"
+        )
+        
+        await mock_host_agent._execute_step(step)
+        
+        # Should only send UIMessage, not StepRequest
+        assert mock_host_agent.publish_message.call_count == 1
+        call_args = mock_host_agent.publish_message.call_args_list[0]
+        
+        message = call_args[0][0]
+        assert isinstance(message, UIMessage)
+        assert message.content == "What would you like to do next?"
+        assert call_args[1]["topic_id"] == mock_host_agent._topic_id
+
+    @pytest.mark.asyncio
+    async def test_end_step_routes_to_main_topic(self, mock_host_agent):
+        """Test that END steps are sent to main topic."""
+        from buttermilk._core.constants import END
+        
+        step = StepRequest(
+            role=END,
+            content="Flow completed"
+        )
+        
+        await mock_host_agent._execute_step(step)
+        
+        # END step should go to main topic
+        assert mock_host_agent.publish_message.call_count == 1
+        call_args = mock_host_agent.publish_message.call_args_list[0]
+        assert isinstance(call_args[0][0], StepRequest)
+        assert call_args[1]["topic_id"] == mock_host_agent._topic_id
+
+    @pytest.mark.asyncio
+    async def test_unknown_role_still_routes_to_role_topic(self, mock_host_agent):
+        """Test that unknown roles still route to role-specific topics."""
+        step = StepRequest(
+            role="UNKNOWN_ROLE",
+            content="Execute unknown step"
+        )
+        
+        await mock_host_agent._execute_step(step)
+        
+        # Should only send StepRequest (no FlowEvent for unknown roles)
+        assert mock_host_agent.publish_message.call_count == 1
+        call_args = mock_host_agent.publish_message.call_args_list[0]
+        assert isinstance(call_args[0][0], StepRequest)
+        assert call_args[1]["topic_id"] == DefaultTopicId(type="UNKNOWN_ROLE")
+
+    @pytest.mark.asyncio
+    async def test_route_tool_calls_uses_role_topics(self, mock_host_agent):
+        """Test that _route_tool_calls_to_agents routes to role-specific topics."""
+        # Mock tool call
+        mock_call = MagicMock()
+        mock_call.name = "researcher_call"
+        mock_call.arguments = '{"query": "test query"}'
+        mock_call.id = "call-123"
+        
+        await mock_host_agent._route_tool_calls_to_agents([mock_call])
+        
+        # Verify StepRequest was sent to RESEARCHER topic
+        assert mock_host_agent.publish_message.call_count == 1
+        call_args = mock_host_agent.publish_message.call_args_list[0]
+        
+        message = call_args[0][0]
+        assert isinstance(message, StepRequest)
+        assert message.role == "RESEARCHER"
+        assert call_args[1]["topic_id"] == DefaultTopicId(type="RESEARCHER")
+
+    @pytest.mark.asyncio
+    async def test_base_agent_publish_with_topic_parameter(self, mock_host_agent):
+        """Test that base Agent._publish method accepts topic_id parameter."""
+        from buttermilk._core.agent import Agent
+        
+        # Create a test message
+        test_message = FlowEvent(content="Test message", source="test")
+        test_topic = DefaultTopicId(type="custom-topic")
+        
+        # Call _publish with custom topic
+        await mock_host_agent._publish(test_message, topic_id=test_topic)
+        
+        # Verify message was published to custom topic
+        mock_host_agent.publish_message.assert_called_once_with(
+            test_message,
+            topic_id=test_topic
+        )
+
+    @pytest.mark.asyncio
+    async def test_base_agent_publish_defaults_to_agent_topic(self, mock_host_agent):
+        """Test that base Agent._publish defaults to agent's topic when no topic specified."""
+        test_message = FlowEvent(content="Test message", source="test")
+        
+        # Call _publish without topic parameter
+        await mock_host_agent._publish(test_message)
+        
+        # Verify message was published to agent's default topic
+        mock_host_agent.publish_message.assert_called_once_with(
+            test_message,
+            topic_id=mock_host_agent._topic_id
+        )


### PR DESCRIPTION
Implements topic routing refactoring requested in issue #141.

## Changes
- Add optional `topic_id` parameter to `Agent._publish()` method
- Update `HostAgent` to route `StepRequest` messages to role-specific topics
- Send `FlowEvent` notifications to main topic when starting steps
- Add comprehensive tests for topic routing

This provides a cleaner implementation than overriding `_publish` in `HostAgent`.

Closes #141

🤖 Generated with [Claude Code](https://claude.ai/code)