### PR TITLE
feat(llm): add DeepSeek provider support via Vertex AI (#326)

### DIFF
--- a/buttermilk/_core/llms.py
+++ b/buttermilk/_core/llms.py
@@ -149,6 +149,7 @@ class ClientType(Enum):
     GEMINI_VERTEX = "gemini_vertex"
     VERTEX_OPENAI = "vertex_openai"  # OpenAI-compatible endpoint on Vertex (legacy)
     LLAMA_VERTEX = "llama_vertex"  # Llama models on Vertex AI via native LiteLLM
+    DEEPSEEK_VERTEX = "deepseek_vertex"  # DeepSeek models on Vertex AI via native LiteLLM
     HUGGINGFACE = "huggingface"  # HuggingFace Inference API (serverless or dedicated)
     ZENTROPI = "zentropi"  # Zentropi toxicity/content moderation API
 
@@ -1376,6 +1377,7 @@ class LLMs(BaseModel):
             "huggingface": "huggingface",
             "vertex_openai": "vertex_ai",  # For litellm pricing, Vertex models need vertex_ai prefix
             "llama_vertex": "vertex_ai",  # Llama on Vertex via native LiteLLM support
+            "deepseek_vertex": "vertex_ai",  # DeepSeek on Vertex via native LiteLLM support
             "anthropic_vertex": "vertex_ai",  # Anthropic-on-Vertex
             "anthropic": "anthropic",
             "zentropi": "zentropi",  # Zentropi custom API
@@ -1467,6 +1469,13 @@ class LLMs(BaseModel):
         # and will construct the full model name as "vertex_ai/meta/llama-..."
         if client_type == "llama_vertex":
             # Keep meta/ prefix - litellm needs it for proper routing
+            return model_name
+
+        # For deepseek_vertex, preserve the deepseek-ai/ prefix for native LiteLLM support
+        # LiteLLM expects model names like "deepseek-ai/deepseek-r1-0528-maas"
+        # and will construct the full model name as "vertex_ai/deepseek-ai/deepseek-r1-..."
+        if client_type == "deepseek_vertex":
+            # Keep deepseek-ai/ prefix - litellm needs it for proper routing
             return model_name
 
         # For anthropic_vertex clients with provider-specific models, preserve format
@@ -1573,9 +1582,21 @@ class LLMs(BaseModel):
             # Don't pass base_url - let LiteLLM construct the correct endpoint
             effective_base_url = None
 
+        elif config.client_type == ClientType.DEEPSEEK_VERTEX:
+            # DeepSeek on Vertex via native LiteLLM support
+            # LiteLLM handles auth and endpoint construction - no base_url needed
+            if not bm.gcp_credentials:
+                raise ValueError("GCP credentials not available for Vertex AI.")
+            vertex_project = config.configs.get("project_id")
+            vertex_location = config.configs.get("region")
+            if not vertex_project or not vertex_location:
+                raise ValueError("project_id and region are required for DeepSeek Vertex AI.")
+            # Don't pass base_url - let LiteLLM construct the correct endpoint
+            effective_base_url = None
+
         # Determine if token_provider is needed for this provider
         token_provider = None
-        if config.client_type in (ClientType.VERTEX_OPENAI, ClientType.GEMINI_VERTEX, ClientType.LLAMA_VERTEX):
+        if config.client_type in (ClientType.VERTEX_OPENAI, ClientType.GEMINI_VERTEX, ClientType.LLAMA_VERTEX, ClientType.DEEPSEEK_VERTEX):
             # Vertex models need GCP token refresh
             def get_vertex_token() -> str:
                 return bm.get_gcp_access_token()

--- a/buttermilk/_core/llms.py
+++ b/buttermilk/_core/llms.py
@@ -134,6 +134,7 @@ class ClientType(Enum):
         GEMINI_VERTEX: Gemini client on vertex platform.
         VERTEX_OPENAI: Google Vertex AI platform with OpenAI-compatible endpoint (legacy).
         LLAMA_VERTEX: Llama models on Vertex AI via native LiteLLM support.
+        DEEPSEEK_VERTEX: DeepSeek models on Vertex AI via native LiteLLM support.
         ANTHROPIC: Anthropic platform (e.g., Claude models).
         ANTHROPIC_VERTEX: Anthropic models hosted on Google Vertex AI.
         llama: Llama models (often self-hosted or via specific providers).
@@ -1570,27 +1571,16 @@ class LLMs(BaseModel):
             vertex_project = config.configs.get("project_id")
             vertex_location = config.configs.get("region")
 
-        elif config.client_type == ClientType.LLAMA_VERTEX:
-            # Llama on Vertex via native LiteLLM support
+        elif config.client_type in (ClientType.LLAMA_VERTEX, ClientType.DEEPSEEK_VERTEX):
+            # Vertex AI MaaS models via native LiteLLM support (Llama, DeepSeek, etc.)
             # LiteLLM handles auth and endpoint construction - no base_url needed
             if not bm.gcp_credentials:
                 raise ValueError("GCP credentials not available for Vertex AI.")
             vertex_project = config.configs.get("project_id")
             vertex_location = config.configs.get("region")
             if not vertex_project or not vertex_location:
-                raise ValueError("project_id and region are required for Llama Vertex AI.")
-            # Don't pass base_url - let LiteLLM construct the correct endpoint
-            effective_base_url = None
-
-        elif config.client_type == ClientType.DEEPSEEK_VERTEX:
-            # DeepSeek on Vertex via native LiteLLM support
-            # LiteLLM handles auth and endpoint construction - no base_url needed
-            if not bm.gcp_credentials:
-                raise ValueError("GCP credentials not available for Vertex AI.")
-            vertex_project = config.configs.get("project_id")
-            vertex_location = config.configs.get("region")
-            if not vertex_project or not vertex_location:
-                raise ValueError("project_id and region are required for DeepSeek Vertex AI.")
+                provider = config.client_type.value
+                raise ValueError(f"project_id and region are required for {provider}.")
             # Don't pass base_url - let LiteLLM construct the correct endpoint
             effective_base_url = None
 

--- a/buttermilk/conf/llms/full.yaml
+++ b/buttermilk/conf/llms/full.yaml
@@ -10,6 +10,7 @@ judgers:
   - gemini-flash
   - claude-sonnet
   - llama-maverick
+  - deepseek-r1
   - gpt-mini
   - gpt-nano
 
@@ -18,6 +19,7 @@ synthesisers:
   - gemini-flash
   - claude-sonnet
   - llama-maverick
+  - deepseek-r1
 
 # Model-specific parameter overrides
 # These override the defaults from models.json for this llms config
@@ -29,4 +31,6 @@ model_parameters:
   claude-sonnet:
     temperature: 1.0
   llama-maverick:
+    temperature: 1.0
+  deepseek-r1:
     temperature: 1.0

--- a/buttermilk/conf/llms/full.yaml
+++ b/buttermilk/conf/llms/full.yaml
@@ -11,6 +11,7 @@ judgers:
   - claude-sonnet
   - llama-maverick
   - deepseek-r1
+  - deepseek-v3
   - gpt-mini
   - gpt-nano
 
@@ -20,6 +21,7 @@ synthesisers:
   - claude-sonnet
   - llama-maverick
   - deepseek-r1
+  - deepseek-v3
 
 # Model-specific parameter overrides
 # These override the defaults from models.json for this llms config
@@ -33,4 +35,6 @@ model_parameters:
   llama-maverick:
     temperature: 1.0
   deepseek-r1:
+    temperature: 1.0
+  deepseek-v3:
     temperature: 1.0

--- a/tests/integration/test_deepseek_vertex.py
+++ b/tests/integration/test_deepseek_vertex.py
@@ -1,0 +1,87 @@
+"""Integration test for DeepSeek models on Vertex AI.
+
+Verifies that DeepSeek R1 (reasoning) and V3.2 (chat) models respond
+correctly via the Buttermilk LLM provider on Vertex AI.
+
+No mocks - this is a TRUE integration test making REAL API calls.
+"""
+
+import pytest
+from autogen_core.models import UserMessage
+
+from buttermilk._core.llms import ClientType, LiteLLMWrapper
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.anyio
+async def test_deepseek_r1_responds(real_bm):
+    """DeepSeek R1 (reasoning model) responds via Vertex AI.
+
+    ARRANGE: Get LiteLLMWrapper for deepseek-r1
+    ACT: Send a simple prompt
+    ASSERT: Response contains expected content
+    """
+    llms = real_bm.llms
+    config = llms.connections.get("deepseek-r1")
+    assert config is not None, "deepseek-r1 not found in connections"
+    assert config.client_type == ClientType.DEEPSEEK_VERTEX
+
+    wrapper = llms.get_client("deepseek-r1")
+    assert isinstance(wrapper, LiteLLMWrapper)
+    assert wrapper.token_provider is not None, "token_provider not set for Vertex model"
+
+    messages = [UserMessage(content="What is 2+2? Answer with just the number.", source="test")]
+    result = await wrapper.create(messages=messages)
+
+    assert result is not None, "API call returned None"
+    assert result.content is not None, "Response has no content"
+    assert len(result.content) > 0, "Response content is empty"
+    assert "4" in str(result.content), f"Expected '4' in response: {result.content}"
+
+
+@pytest.mark.anyio
+async def test_deepseek_v3_responds(real_bm):
+    """DeepSeek V3.2 (chat model) responds via Vertex AI.
+
+    ARRANGE: Get LiteLLMWrapper for deepseek-v3
+    ACT: Send a simple prompt
+    ASSERT: Response contains expected content
+    """
+    llms = real_bm.llms
+    config = llms.connections.get("deepseek-v3")
+    assert config is not None, "deepseek-v3 not found in connections"
+    assert config.client_type == ClientType.DEEPSEEK_VERTEX
+
+    wrapper = llms.get_client("deepseek-v3")
+    assert isinstance(wrapper, LiteLLMWrapper)
+    assert wrapper.token_provider is not None, "token_provider not set for Vertex model"
+
+    messages = [UserMessage(content="What is 2+2? Answer with just the number.", source="test")]
+    result = await wrapper.create(messages=messages)
+
+    assert result is not None, "API call returned None"
+    assert result.content is not None, "Response has no content"
+    assert len(result.content) > 0, "Response content is empty"
+    assert "4" in str(result.content), f"Expected '4' in response: {result.content}"
+
+
+@pytest.mark.anyio
+async def test_deepseek_models_use_correct_regions(real_bm):
+    """DeepSeek models are configured with correct Vertex AI regions.
+
+    R1 must use us-central1, V3.2 must use global.
+    """
+    llms = real_bm.llms
+
+    r1_config = llms.connections.get("deepseek-r1")
+    assert r1_config is not None
+    assert r1_config.configs.get("region") == "us-central1", (
+        f"deepseek-r1 region should be us-central1, got {r1_config.configs.get('region')}"
+    )
+
+    v3_config = llms.connections.get("deepseek-v3")
+    assert v3_config is not None
+    assert v3_config.configs.get("region") == "global", (
+        f"deepseek-v3 region should be global, got {v3_config.configs.get('region')}"
+    )

--- a/tests/unit/test_llm_config_refactor.py
+++ b/tests/unit/test_llm_config_refactor.py
@@ -17,6 +17,7 @@ def test_client_type_enum():
         "gemini_vertex",
         "vertex_openai",
         "llama_vertex",
+        "deepseek_vertex",
         "huggingface",
         "zentropi",
     ]

--- a/tests/unit/test_llms_pricing.py
+++ b/tests/unit/test_llms_pricing.py
@@ -92,6 +92,13 @@ class TestLiteLLMModelNameResolution:
         )
         assert result == "vertex_ai/meta/llama-4-maverick-17b-128e-instruct-maas"
 
+    def test_deepseek_vertex_resolution(self):
+        """Test DeepSeek models on Vertex resolve correctly."""
+        result = LLMs.lookup_litellm_model_name(
+            "deepseek-ai/deepseek-r1-0528-maas", "deepseek_vertex"
+        )
+        assert result == "vertex_ai/deepseek-ai/deepseek-r1-0528-maas"
+
     def test_existing_prefix_handling(self):
         """Test models that already have provider prefixes are handled correctly."""
         # If a model already has the expected prefix, it should be returned as-is
@@ -127,6 +134,7 @@ class TestLiteLLMModelNameResolution:
         assert LLMs._provider_prefix_for_client_type("gemini_vertex") == "gemini"
         assert LLMs._provider_prefix_for_client_type("vertex_openai") == "vertex_ai"
         assert LLMs._provider_prefix_for_client_type("anthropic_vertex") == "vertex_ai"
+        assert LLMs._provider_prefix_for_client_type("deepseek_vertex") == "vertex_ai"
         assert LLMs._provider_prefix_for_client_type("anthropic") == "anthropic"
 
     def test_base_model_name_extraction(self):
@@ -175,6 +183,12 @@ class TestLiteLLMModelNameResolution:
             "claude-sonnet-4@20250514", "anthropic_vertex"
         )
         assert result == "vertex_ai/claude-sonnet-4@20250514"
+
+        # Test DeepSeek on Vertex - should preserve deepseek-ai/ prefix
+        result = LLMs.lookup_litellm_model_name(
+            "deepseek-ai/deepseek-r1-0528-maas", "deepseek_vertex"
+        )
+        assert result == "vertex_ai/deepseek-ai/deepseek-r1-0528-maas"
 
 
 class TestLiteLLMIntegration:


### PR DESCRIPTION
## Summary
- Adds `DEEPSEEK_VERTEX` client type to support DeepSeek models on Google Vertex AI via native LiteLLM routing (`vertex_ai/deepseek-ai/{model}`)
- Adds `deepseek-r1` model config (`deepseek-ai/deepseek-r1-0528-maas`, us-central1 region)
- Adds `deepseek-v3` model config (`deepseek-ai/deepseek-v3.2-maas`, global region)
- Adds both models to `judgers` and `synthesisers` role lists in `full.yaml`

## Changes
| File | Change |
|------|--------|
| `buttermilk/_core/llms.py` | `DEEPSEEK_VERTEX` enum, provider prefix mapping, model name extraction, `get_client()` branch, token provider |
| `buttermilk/conf/llms/full.yaml` | Added `deepseek-r1` and `deepseek-v3` to judgers, synthesisers, and model_parameters |
| `tests/unit/test_llm_config_refactor.py` | Added `deepseek_vertex` to expected enum types |
| `tests/unit/test_llms_pricing.py` | Tests for model name resolution, prefix mapping, and real-world registry |
| `tests/integration/test_deepseek_vertex.py` | Integration tests verifying both models respond on Vertex AI |

## Test plan
- [x] TDD red phase: 4 tests written first, confirmed failing
- [x] TDD green phase: all 30 unit tests pass (0 failures)
- [x] Integration test: DeepSeek R1 responds via Vertex AI (us-central1)
- [x] Integration test: DeepSeek V3.2 responds via Vertex AI (global)
- [x] Integration test: region configuration verified (R1=us-central1, V3=global)

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)