### PR TITLE
⚡ Optimize BatchPipelineRunner expander loop

### DIFF
--- a/buttermilk/batch/runner.py
+++ b/buttermilk/batch/runner.py
@@ -1,3 +1,4 @@
+import asyncio
 from typing import AsyncGenerator
 
 from pydantic import ConfigDict, Field
@@ -119,14 +120,19 @@ class BatchPipelineRunner(ProcessorCore):
 
         current_records = records
         for proc in self.expanders:
-            next_records = []
-            for record in current_records:
+
+            async def _process_single(record: BaseRecord) -> list[BaseRecord]:
+                """Process a single record and collect results."""
                 # Create context for each record
                 # TODO: Use shared session ID
                 ctx = ProcessingContext(session_id="batch_preproc", record=record)
-                async for res in proc.process(ctx):
-                    next_records.append(res)
-            current_records = next_records
+                return [res async for res in proc.process(ctx)]
+
+            # Parallelize processing of all records for the current expander
+            results = await asyncio.gather(*(_process_single(record) for record in current_records))
+
+            # Flatten results for the next expander (or final output)
+            current_records = [res for record_list in results for res in record_list]
 
         return current_records
 

--- a/tests/investigations/test_performance_batch_runner.py
+++ b/tests/investigations/test_performance_batch_runner.py
@@ -1,0 +1,44 @@
+import asyncio
+import time
+import pytest
+from typing import AsyncGenerator
+from buttermilk._core.processor_core import ProcessorCore, BatchProcessorCore
+from buttermilk._core.types import BaseRecord
+from buttermilk._core.processing_context import ProcessingContext
+from buttermilk.batch.runner import BatchPipelineRunner
+from buttermilk.batch.executors.sync import SyncBatchExecutor
+
+class SlowExpander(ProcessorCore):
+    async def _process_record(self, context: ProcessingContext) -> AsyncGenerator[BaseRecord, None]:
+        await asyncio.sleep(0.1)
+        yield context.record
+
+class FastBatchProcessor(BatchProcessorCore):
+    async def _process_batch(self, records: list[BaseRecord]) -> list[BaseRecord]:
+        return records
+
+@pytest.mark.anyio
+async def test_performance_batch_runner_expanders():
+    num_records = 10
+    records = [BaseRecord(record_id=f"rec-{i}", content=f"content-{i}") for i in range(num_records)]
+
+    runner = BatchPipelineRunner(
+        name="test_runner",
+        source=records,
+        batch_processor=FastBatchProcessor(),
+        expanders=[SlowExpander()],
+        executor=SyncBatchExecutor()
+    )
+
+    start_time = time.perf_counter()
+    await runner.run()
+    end_time = time.perf_counter()
+
+    duration = end_time - start_time
+    print(f"\nTime taken for {num_records} records: {duration:.4f} seconds")
+
+    # If sequential, it should take at least 1.0 seconds (10 * 0.1)
+    # If parallel, it should take around 0.1-0.2 seconds
+    # Note: This is a performance test, so we just log the time for now.
+    # We can add an assertion if we want to enforce parallel execution.
+    # assert duration < 0.5


### PR DESCRIPTION
This PR optimizes the `BatchPipelineRunner` by parallelizing the expansion stage.

### 💡 What:
Replaced the sequential `async for` loop in `_run_expanders` with `asyncio.gather`.

### 🎯 Why:
The previous implementation processed records one by one, which is inefficient for batch operations that are primarily I/O-bound. Parallelizing this stage allows the pipeline to scale better with the number of input records.

### 📊 Measured Improvement:
While local environment restrictions prevented running the full test suite, a performance benchmark has been added to `tests/investigations/test_performance_batch_runner.py`. The optimization follows standard async parallelization patterns and is expected to reduce execution time from linear (with respect to record count) to near-constant for the expansion phase.


---
*PR created automatically by Jules for task [2934928990143830375](https://jules.google.com/task/2934928990143830375) started by @nicsuzor*