### PR TITLE
Fix: VariantProcessor batch integration and OpenAIBatch dynamic params (#347)

### DIFF
--- a/buttermilk/processors/openai_batch.py
+++ b/buttermilk/processors/openai_batch.py
@@ -306,6 +306,16 @@ class OpenAIBatchProcessor(BatchProcessorCore):
         if not requests:
             raise FatalError("No valid records found for batch processing")
 
+        # Enforce that all requests use the same model.  Mixed-model batches are not
+        # supported: the batch submission and cost calculation both use a single model
+        # identifier.  If different models are needed, use separate processor instances.
+        models_in_batch = {req.model for req in requests}
+        if len(models_in_batch) > 1:
+            raise FatalError(
+                f"Mixed models in a single OpenAI batch are not supported: {models_in_batch}. "
+                "Use a separate OpenAIBatchProcessor instance for each model."
+            )
+
         return requests
 
     async def _process_batch(

--- a/buttermilk/processors/openai_batch.py
+++ b/buttermilk/processors/openai_batch.py
@@ -191,7 +191,33 @@ class OpenAIBatchProcessor(BatchProcessorCore):
 
         return self._manager
 
-    def prepare_batch_requests(
+    def _resolve_field(self, field_name: str, record: BaseRecord) -> Any:
+        """Resolve a configuration field, checking for overrides in record metadata.
+
+        Resolution order:
+        1. record.metadata[field_name]
+        2. self[field_name] (configured default)
+
+        Args:
+            field_name: Name of the field to resolve (e.g., 'model', 'template')
+            record: Record to check metadata
+
+        Returns:
+            Resolved value for the field.
+        """
+        # 1. Check record metadata
+        if record.metadata:
+            if field_name in record.metadata:
+                return record.metadata[field_name]
+            # Also check nested 'variant_params' from VariantProcessor
+            variant_params = record.metadata.get("variant_params", {})
+            if isinstance(variant_params, dict) and field_name in variant_params:
+                return variant_params[field_name]
+
+        # 2. Fallback to configured default
+        return getattr(self, field_name, None)
+
+    def prepare_batch_requests(  # noqa: PLR0912
         self,
         records: list[BaseRecord],
     ) -> list[Any]:
@@ -201,6 +227,10 @@ class OpenAIBatchProcessor(BatchProcessorCore):
         requests: list[BatchRequest] = []
 
         for record in records:
+            # Dynamically resolve model and template for this record
+            resolved_model = self._resolve_field("model", record)
+            resolved_template = self._resolve_field("template", record)
+
             # Prepare template variables
             if hasattr(record, "model_dump"):
                 record_dict = record.model_dump()
@@ -219,7 +249,7 @@ class OpenAIBatchProcessor(BatchProcessorCore):
 
             try:
                 result = render_template(
-                    template=self.template,
+                    template=resolved_template,
                     template_vars=variant_vars,
                     base_template_vars=self.template_vars,
                     fail_on_unfilled=self.fail_on_unfilled_parameters,
@@ -253,8 +283,8 @@ class OpenAIBatchProcessor(BatchProcessorCore):
                     processor_index = variant_info.get("index")
 
             structured_variant: dict[str, Any] = {
-                "template": self.template,
-                "model": self.model,
+                "template": resolved_template,
+                "model": resolved_model,
             }
             if variant_from_metadata:
                 if isinstance(variant_from_metadata, dict):
@@ -266,7 +296,7 @@ class OpenAIBatchProcessor(BatchProcessorCore):
                 custom_id=str(uuid.uuid4()),
                 record_id=record.record_id,
                 messages=litellm_messages,
-                model=self.model,
+                model=resolved_model,
                 variant=structured_variant,
                 processor_index=processor_index,
                 response_schema=self._output_schema,

--- a/buttermilk/processors/variants.py
+++ b/buttermilk/processors/variants.py
@@ -174,6 +174,7 @@ class VariantProcessor(ProcessorCore):
         original_task_count = len(tasks)
         completed_count = 0
         success_count = 0
+        buffered_count = 0
         first_error: Exception | None = None
 
         # Yield results as they arrive in the queue
@@ -192,14 +193,14 @@ class VariantProcessor(ProcessorCore):
                     variant_idx, output, error = await asyncio.wait_for(output_queue.get(), timeout=0.1)
 
                     if error is not None:
-                        # Issue 1: Handle RecordBufferedException specially
+                        # Handle RecordBufferedException: this variant buffered the record
+                        # (e.g. inside a BatchAccumulator). Do NOT cancel other variants —
+                        # each sibling variant must independently decide to buffer or produce
+                        # output. We raise RecordBufferedException to the pipeline only after
+                        # all variants have completed and none produced any output.
                         if isinstance(error, RecordBufferedException):
-                            # Propagate buffer signal immediately
-                            # This cancels other variants and bubbles up to pipeline
-                            for task in tasks:
-                                if not task.done():
-                                    task.cancel()
-                            raise error
+                            buffered_count += 1
+                            continue
 
                         # Handle variant failure
                         logger.warning(
@@ -234,9 +235,17 @@ class VariantProcessor(ProcessorCore):
             if tasks:
                 await asyncio.gather(*tasks, return_exceptions=True)
 
-        # If ALL variants failed and we haven't raised yet, raise the first error
-        if success_count == 0 and first_error is not None:
-            raise first_error
+        # All variants have completed. Decide how to signal the outcome to the pipeline.
+        if success_count == 0:
+            if buffered_count > 0 and first_error is None:
+                # Every variant either buffered the record (or was skipped).
+                # Signal the pipeline that this record was buffered, not failed.
+                raise RecordBufferedException(
+                    f"All {buffered_count} variant(s) buffered this record for later batch processing"
+                )
+            if first_error is not None:
+                # All non-buffering variants failed; raise the first error seen.
+                raise first_error
 
     async def flush(self) -> AsyncGenerator[BaseRecord, None]:
         """Delegate flush to all inner processors."""

--- a/buttermilk/processors/variants.py
+++ b/buttermilk/processors/variants.py
@@ -14,6 +14,7 @@ from buttermilk._core.log import logger
 from buttermilk._core.processing_context import ProcessingContext
 from buttermilk._core.processor_core import ProcessorCore
 from buttermilk._core.types import BaseRecord
+from buttermilk.pipeline import RecordBufferedException
 
 
 class VariantProcessor(ProcessorCore):
@@ -103,7 +104,7 @@ class VariantProcessor(ProcessorCore):
             variant_count=len(self._processors),
         )
 
-    async def _process_record(
+    async def _process_record(  # noqa: PLR0912
         self,
         context: ProcessingContext,
     ) -> AsyncGenerator[BaseRecord, None]:
@@ -136,6 +137,7 @@ class VariantProcessor(ProcessorCore):
                 )
 
                 async for output in processor.process(variant_context):
+                    processed_output = output
                     # Add variant metadata immediately and put in queue
                     # Support typed data flow: only add metadata to records that support it
                     if hasattr(output, "metadata") and hasattr(output, "model_copy"):
@@ -151,10 +153,13 @@ class VariantProcessor(ProcessorCore):
                         if hasattr(processor, "model_dump"):
                             metadata["variant_params"] = processor.model_dump(exclude_none=True)
 
-                        output = output.model_copy(update={"metadata": metadata})
+                        processed_output = output.model_copy(update={"metadata": metadata})
 
                     # Put (variant_idx, output, None) - None means no error
-                    await output_queue.put((variant_idx, output, None))
+                    await output_queue.put((variant_idx, processed_output, None))
+            except RecordBufferedException as e:
+                # Issue 1: Propagate RecordBufferedException to main loop
+                await output_queue.put((variant_idx, None, e))
             except Exception as e:
                 # Put (variant_idx, None, error) - signal failure
                 await output_queue.put((variant_idx, None, e))
@@ -187,6 +192,15 @@ class VariantProcessor(ProcessorCore):
                     variant_idx, output, error = await asyncio.wait_for(output_queue.get(), timeout=0.1)
 
                     if error is not None:
+                        # Issue 1: Handle RecordBufferedException specially
+                        if isinstance(error, RecordBufferedException):
+                            # Propagate buffer signal immediately
+                            # This cancels other variants and bubbles up to pipeline
+                            for task in tasks:
+                                if not task.done():
+                                    task.cancel()
+                            raise error
+
                         # Handle variant failure
                         logger.warning(
                             f"Variant {variant_idx} failed: {error}",
@@ -223,3 +237,10 @@ class VariantProcessor(ProcessorCore):
         # If ALL variants failed and we haven't raised yet, raise the first error
         if success_count == 0 and first_error is not None:
             raise first_error
+
+    async def flush(self) -> AsyncGenerator[BaseRecord, None]:
+        """Delegate flush to all inner processors."""
+        for processor in self._processors:
+            if hasattr(processor, "flush"):
+                async for output in processor.flush():
+                    yield output

--- a/tests/processors/test_variants_processors.py
+++ b/tests/processors/test_variants_processors.py
@@ -4,8 +4,8 @@ import asyncio
 
 import pytest
 
-from buttermilk._core.types import BaseRecord
 from buttermilk._core.processing_context import ProcessingContext
+from buttermilk._core.types import BaseRecord
 from buttermilk.processors.variants import VariantProcessor
 
 
@@ -99,10 +99,7 @@ class TestVariantProcessorIntegration:
         """Test that all variants produce outputs."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="test-1", content="hello")
-        context = ProcessingContext(
-            record=record,
-            session_id="test/00.Variant/abc123"
-        )
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
 
         outputs = []
         async for output in proc.process(context):
@@ -117,10 +114,7 @@ class TestVariantProcessorIntegration:
         """Test that variant metadata is added to outputs."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="test-1", content="hello")
-        context = ProcessingContext(
-            record=record,
-            session_id="test/00.Variant/abc123"
-        )
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
 
         outputs = []
         async for output in proc.process(context):
@@ -138,10 +132,7 @@ class TestVariantProcessorIntegration:
         """Test that faster variants yield results first."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="test-1", content="hello")
-        context = ProcessingContext(
-            record=record,
-            session_id="test/00.Variant/abc123"
-        )
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
 
         # Track order of completion
         completion_order = []
@@ -175,10 +166,7 @@ class TestVariantProcessorIntegration:
         ]
 
         record = BaseRecord(record_id="test-1", content="hello")
-        context = ProcessingContext(
-            record=record,
-            session_id="test/00.Variant/abc123"
-        )
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
 
         outputs = []
         async for output in proc.process(context):
@@ -212,10 +200,7 @@ class TestVariantProcessorIntegration:
         ]
 
         record = BaseRecord(record_id="test-1", content="hello")
-        context = ProcessingContext(
-            record=record,
-            session_id="test/00.Variant/abc123"
-        )
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
 
         with pytest.raises(ValueError, match="configured to fail"):
             async for _ in proc.process(context):
@@ -226,10 +211,7 @@ class TestVariantProcessorIntegration:
         """Test that original record_id is preserved in outputs."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="original-id-123", content="hello")
-        context = ProcessingContext(
-            record=record,
-            session_id="test/00.Variant/abc123"
-        )
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
 
         async for output in proc.process(context):
             assert output.record_id == "original-id-123"

--- a/tests/processors/test_variants_processors.py
+++ b/tests/processors/test_variants_processors.py
@@ -6,6 +6,7 @@ import pytest
 
 from buttermilk._core.processing_context import ProcessingContext
 from buttermilk._core.types import BaseRecord
+from buttermilk.pipeline import RecordBufferedException
 from buttermilk.processors.variants import VariantProcessor
 
 
@@ -38,6 +39,27 @@ class MockProcessor:
                 "content": f"{record.content}_{self.suffix}",
             }
         )
+
+
+class MockBufferingProcessor:
+    """Mock processor that simulates a BatchAccumulator by raising RecordBufferedException."""
+
+    def __init__(self, suffix: str = ""):
+        self.suffix = suffix
+        self.buffered: list = []
+        self.name = None
+
+    async def process(self, context: ProcessingContext):
+        """Buffer the record and raise RecordBufferedException (no yield)."""
+        self.buffered.append(context.record)
+        raise RecordBufferedException(f"Buffered by MockBufferingProcessor({self.suffix})")
+        yield  # Make this an async generator
+
+    async def flush(self):
+        """Flush buffered records as outputs."""
+        for record in self.buffered:
+            yield record.model_copy(update={"content": f"{record.content}_{self.suffix}"})
+        self.buffered.clear()
 
 
 class TestVariantProcessorUnit:
@@ -215,6 +237,113 @@ class TestVariantProcessorIntegration:
 
         async for output in proc.process(context):
             assert output.record_id == "original-id-123"
+
+    @pytest.mark.anyio
+    async def test_buffering_variant_does_not_cancel_siblings(self):
+        """Test that a variant raising RecordBufferedException doesn't cancel other variants.
+
+        Regression test for Issue #347: previously RecordBufferedException would cancel
+        all sibling tasks immediately, so batch variants never got to buffer their records.
+        """
+        buf1 = MockBufferingProcessor(suffix="BUF1")
+        buf2 = MockBufferingProcessor(suffix="BUF2")
+
+        proc = object.__new__(VariantProcessor)
+        proc.__dict__.update(
+            {
+                "name": None,
+                "enabled": True,
+                "processor_obj": "mock.Processor",
+                "variants": {},
+                "num_runs": 1,
+                "parameters": {},
+                "fail_on_error": False,
+            }
+        )
+        proc._processors = [buf1, buf2]
+
+        record = BaseRecord(record_id="buf-test-1", content="hello")
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
+
+        # All variants buffered → should raise RecordBufferedException, not produce outputs
+        with pytest.raises(RecordBufferedException):
+            async for _ in proc.process(context):
+                pass
+
+        # Both processors must have buffered the record (neither was cancelled)
+        assert len(buf1.buffered) == 1, "buf1 was cancelled before it could buffer"
+        assert len(buf2.buffered) == 1, "buf2 was cancelled before it could buffer"
+
+    @pytest.mark.anyio
+    async def test_buffering_and_success_variants_mixed(self):
+        """Test that buffering variants and successful variants can coexist.
+
+        When some variants buffer and others produce output, the outputs should be
+        yielded normally (the buffered variants are silently absorbed).
+        """
+        buf = MockBufferingProcessor(suffix="BUF")
+        ok = MockProcessor(suffix="OK")
+
+        proc = object.__new__(VariantProcessor)
+        proc.__dict__.update(
+            {
+                "name": None,
+                "enabled": True,
+                "processor_obj": "mock.Processor",
+                "variants": {},
+                "num_runs": 1,
+                "parameters": {},
+                "fail_on_error": False,
+            }
+        )
+        proc._processors = [buf, ok]
+
+        record = BaseRecord(record_id="mixed-test-1", content="hello")
+        context = ProcessingContext(record=record, session_id="test/00.Variant/abc123")
+
+        outputs = []
+        async for output in proc.process(context):
+            outputs.append(output)
+
+        # The successful variant should yield its output
+        assert len(outputs) == 1
+        assert outputs[0].content == "hello_OK"
+
+        # The buffering variant should have buffered the record
+        assert len(buf.buffered) == 1
+
+    @pytest.mark.anyio
+    async def test_flush_delegates_to_inner_processors(self):
+        """Test that VariantProcessor.flush() calls flush() on all inner processors."""
+        buf1 = MockBufferingProcessor(suffix="BUF1")
+        buf2 = MockBufferingProcessor(suffix="BUF2")
+
+        # Pre-populate buffers as if records were already buffered
+        dummy = BaseRecord(record_id="flush-1", content="world")
+        buf1.buffered.append(dummy)
+        buf2.buffered.append(dummy)
+
+        proc = object.__new__(VariantProcessor)
+        proc.__dict__.update(
+            {
+                "name": None,
+                "enabled": True,
+                "processor_obj": "mock.Processor",
+                "variants": {},
+                "num_runs": 1,
+                "parameters": {},
+                "fail_on_error": False,
+            }
+        )
+        proc._processors = [buf1, buf2]
+
+        flushed = []
+        async for output in proc.flush():
+            flushed.append(output)
+
+        assert len(flushed) == 2
+        contents = {o.content for o in flushed}
+        assert contents == {"world_BUF1", "world_BUF2"}
 
 
 class TestProcessorVariantsConfig:

--- a/tests/processors/test_variants_processors.py
+++ b/tests/processors/test_variants_processors.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from buttermilk._core.types import BaseRecord
+from buttermilk._core.processing_context import ProcessingContext
 from buttermilk.processors.variants import VariantProcessor
 
 
@@ -19,14 +20,11 @@ class MockProcessor:
 
     async def process(
         self,
-        record: BaseRecord,
-        *,
-        processor_stage: str,
-        parent_trace_id: str | None = None,
-        **kwargs,
+        context: ProcessingContext,
     ):
         """Process record, optionally with delay or failure."""
         self.call_count += 1
+        record = context.record
 
         if self.delay > 0:
             await asyncio.sleep(self.delay)
@@ -79,6 +77,8 @@ class TestVariantProcessorIntegration:
         # Initialize Pydantic model fields manually
         proc.__dict__.update(
             {
+                "name": None,
+                "enabled": True,
                 "processor_obj": "mock.Processor",
                 "variants": {"suffix": ["A", "B", "C"]},
                 "num_runs": 1,
@@ -99,9 +99,13 @@ class TestVariantProcessorIntegration:
         """Test that all variants produce outputs."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="test-1", content="hello")
+        context = ProcessingContext(
+            record=record,
+            session_id="test/00.Variant/abc123"
+        )
 
         outputs = []
-        async for output in proc.process(record, processor_stage="test/00.Variant/abc123"):
+        async for output in proc.process(context):
             outputs.append(output)
 
         assert len(outputs) == 3
@@ -113,9 +117,13 @@ class TestVariantProcessorIntegration:
         """Test that variant metadata is added to outputs."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="test-1", content="hello")
+        context = ProcessingContext(
+            record=record,
+            session_id="test/00.Variant/abc123"
+        )
 
         outputs = []
-        async for output in proc.process(record, processor_stage="test/00.Variant/abc123"):
+        async for output in proc.process(context):
             outputs.append(output)
 
         for output in outputs:
@@ -130,10 +138,14 @@ class TestVariantProcessorIntegration:
         """Test that faster variants yield results first."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="test-1", content="hello")
+        context = ProcessingContext(
+            record=record,
+            session_id="test/00.Variant/abc123"
+        )
 
         # Track order of completion
         completion_order = []
-        async for output in proc.process(record, processor_stage="test/00.Variant/abc123"):
+        async for output in proc.process(context):
             completion_order.append(output.content)
 
         # B (0.05s) should complete before A (0.1s) before C (0.15s)
@@ -147,6 +159,8 @@ class TestVariantProcessorIntegration:
         proc = object.__new__(VariantProcessor)
         proc.__dict__.update(
             {
+                "name": None,
+                "enabled": True,
                 "processor_obj": "mock.Processor",
                 "variants": {},
                 "num_runs": 1,
@@ -161,9 +175,13 @@ class TestVariantProcessorIntegration:
         ]
 
         record = BaseRecord(record_id="test-1", content="hello")
+        context = ProcessingContext(
+            record=record,
+            session_id="test/00.Variant/abc123"
+        )
 
         outputs = []
-        async for output in proc.process(record, processor_stage="test/00.Variant/abc123"):
+        async for output in proc.process(context):
             outputs.append(output)
 
         # Should get 2 successful outputs (failed variant is logged but doesn't yield)
@@ -179,6 +197,8 @@ class TestVariantProcessorIntegration:
         proc = object.__new__(VariantProcessor)
         proc.__dict__.update(
             {
+                "name": None,
+                "enabled": True,
                 "processor_obj": "mock.Processor",
                 "variants": {},
                 "num_runs": 1,
@@ -192,9 +212,13 @@ class TestVariantProcessorIntegration:
         ]
 
         record = BaseRecord(record_id="test-1", content="hello")
+        context = ProcessingContext(
+            record=record,
+            session_id="test/00.Variant/abc123"
+        )
 
         with pytest.raises(ValueError, match="configured to fail"):
-            async for _ in proc.process(record, processor_stage="test/00.Variant/abc123"):
+            async for _ in proc.process(context):
                 pass
 
     @pytest.mark.anyio
@@ -202,8 +226,12 @@ class TestVariantProcessorIntegration:
         """Test that original record_id is preserved in outputs."""
         proc = variant_processor_with_mocks
         record = BaseRecord(record_id="original-id-123", content="hello")
+        context = ProcessingContext(
+            record=record,
+            session_id="test/00.Variant/abc123"
+        )
 
-        async for output in proc.process(record, processor_stage="test/00.Variant/abc123"):
+        async for output in proc.process(context):
             assert output.record_id == "original-id-123"
 
 


### PR DESCRIPTION
This PR addresses Issue #347 regarding VariantProcessor wrapping batch processors.

Changes:
1.  **VariantProcessor Fixes**:
    *   Propagate `RecordBufferedException` from inner processors (e.g. `BatchAccumulator`) directly to the pipeline orchestrator. Previously, this was caught as a generic exception, logged as a warning, and re-raised, which could cancel parallel variants and mislead the pipeline logic.
    *   Implement `flush()` method to delegate to inner processors. This ensures buffered records in batch processors are flushed when the pipeline completes.

2.  **OpenAIBatchProcessor Fixes**:
    *   Implement `_resolve_field` method (similar to `BatchLLMProcessor`) to resolve configuration fields dynamically.
    *   Update `prepare_batch_requests` to use `_resolve_field` for `model` and `template`, allowing per-record overrides from `record.metadata` (essential for `VariantProcessor` operations).

3.  **Test Fixes**:
    *   Updated `tests/processors/test_variants_processors.py` to use `ProcessingContext` correctly, fixing broken tests that were passing invalid arguments to `process()`.
    *   Added `name` attribute to mock processor setup in tests to satisfy `ProcessorCore` requirements.

---
*PR created automatically by Jules for task [4604166127051969816](https://jules.google.com/task/4604166127051969816) started by @nicsuzor*