### PR TITLE
Update PR #344 - Fix unrelated history and resolve conflicts

### DIFF
--- a/tests/investigations/test_performance_batch_runner.py
+++ b/tests/investigations/test_performance_batch_runner.py
@@ -1,0 +1,45 @@
+import asyncio
+import time
+from typing import AsyncGenerator
+
+import pytest
+
+from buttermilk._core.processing_context import ProcessingContext
+from buttermilk._core.processor_core import BatchProcessorCore, ProcessorCore
+from buttermilk._core.types import BaseRecord
+from buttermilk.batch.executors.sync import SyncBatchExecutor
+from buttermilk.batch.runner import BatchPipelineRunner
+
+
+class SlowExpander(ProcessorCore):
+    async def _process_record(self, context: ProcessingContext) -> AsyncGenerator[BaseRecord, None]:
+        await asyncio.sleep(0.1)
+        yield context.record
+
+
+class FastBatchProcessor(BatchProcessorCore):
+    async def _process_batch(self, records: list[BaseRecord]) -> list[BaseRecord]:
+        return records
+
+
+@pytest.mark.anyio
+async def test_performance_batch_runner_expanders() -> None:
+    num_records = 10
+    records = [BaseRecord(record_id=f"rec-{i}", content=f"content-{i}") for i in range(num_records)]
+
+    runner = BatchPipelineRunner(
+        name="test_runner", source=records, batch_processor=FastBatchProcessor(), expanders=[SlowExpander()], executor=SyncBatchExecutor()
+    )
+
+    start_time = time.perf_counter()
+    await runner.run()
+    end_time = time.perf_counter()
+
+    duration = end_time - start_time
+    print(f"\nTime taken for {num_records} records: {duration:.4f} seconds")
+
+    # If sequential, it should take at least 1.0 seconds (10 * 0.1)
+    # If parallel, it should take around 0.1-0.2 seconds
+    # Note: This is a performance test, so we just log the time for now.
+    # We can add an assertion if we want to enforce parallel execution.
+    # assert duration < 0.5

--- a/tests/unit/test_fetch_batch_results_unbound.py
+++ b/tests/unit/test_fetch_batch_results_unbound.py
@@ -10,19 +10,19 @@ sys.path.append(os.getcwd())
 from scripts.fetch_batch_results import fetch_results
 
 
-@pytest.mark.asyncio
-async def test_fetch_results_anypath_accessible():
+@pytest.mark.anyio
+async def test_fetch_results_anypath_accessible() -> None:
     """Test that AnyPath is accessible even if Strategy 1 is skipped."""
+    # Build mock_bm before patching to avoid introspecting the uninitialized bm proxy
+    mock_bm = MagicMock()
+    mock_bm.session_info.save_dir_base = None
+    mock_bm.session_info.save_dir = "gs://test-bucket/runs/test-session"
+
     with (
         patch("scripts.fetch_batch_results.init_async"),
-        patch("scripts.fetch_batch_results.bm") as mock_bm,
+        patch("scripts.fetch_batch_results.bm", new=mock_bm),
         patch("scripts.fetch_batch_results.AnyPath") as mock_anypath,
     ):
-        # Setup mock session info to skip strategy 1
-        mock_bm.session_info.save_dir_base = None
-        # But enable strategy 2 or 3
-        mock_bm.session_info.save_dir = "gs://test-bucket/runs/test-session"
-
         # Mock AnyPath behavior
         mock_path = MagicMock()
         mock_anypath.return_value = mock_path


### PR DESCRIPTION
This PR update resolves the conflict caused by an orphan commit in PR #344. It cherry-picks the intended changes (fixing `test_fetch_batch_results_unbound` and adding a performance test) onto the current `dev` branch.

Changes:
1.  Modified `tests/unit/test_fetch_batch_results_unbound.py` to use `@pytest.mark.anyio` and pre-build the `bm` mock to avoid introspection issues.
2.  Added `tests/investigations/test_performance_batch_runner.py` as a performance investigation test.
3.  Added type hints (`-> None`) to the test functions to satisfy `mypy`.
4.  Verified tests pass with `pytest`.
5.  Verified code quality with `ruff` and `mypy`.

---
*PR created automatically by Jules for task [5216442322129809248](https://jules.google.com/task/5216442322129809248) started by @nicsuzor*