### PR TITLE
Modernize release versioning with setuptools_scm and CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release Versioning
+
+on:
+  push:
+    branches:
+      - dev
+      - stable
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for git describe to find tags
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: |
+          pip install packaging
+
+      - name: Bump version and tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python scripts/release/bump_version.py

--- a/buttermilk/__init__.py
+++ b/buttermilk/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from typing import TYPE_CHECKING
 
 import structlog
@@ -25,6 +26,11 @@ from ._core.constants import (
 
 tracer = trace.get_tracer(_TRACER_NAME)
 logger = structlog.get_logger(_LOGGER_NAME)
+
+try:
+    __version__ = importlib.metadata.version("buttermilk")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "unknown"
 
 
 class BMAccessor:
@@ -160,6 +166,7 @@ __all__ = [
     "stdout_redirected_to_stderr",
     "stdout_suppressed",
     "suppress_stdout_completely",
+    "__version__",
 ]
 
 # Replace the placeholder BM with the real class now that all imports are complete

--- a/buttermilk/processors/vertex_batch.py
+++ b/buttermilk/processors/vertex_batch.py
@@ -879,13 +879,17 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         from buttermilk import bm
 
         if self.model not in bm.llms.connections:
-            raise ValueError(f"Model '{self.model}' not found in buttermilk LLM registry. Available models: {list(bm.llms.connections.keys())}")
+            raise ValueError(
+                f"Model '{self.model}' not found in buttermilk LLM registry. "
+                f"Available models: {list(bm.llms.connections.keys())}"
+            )
 
         config = bm.llms.connections[self.model]
 
         if config.client_type.value not in ("azure", "openai"):
             raise ValueError(
-                f"OpenAIBatchProcessor requires an OpenAI or Azure model, but '{self.model}' has client_type='{config.client_type.value}'"
+                f"OpenAIBatchProcessor requires an OpenAI or Azure model, "
+                f"but '{self.model}' has client_type='{config.client_type.value}'"
             )
 
         if config.client_type.value == "azure":
@@ -914,8 +918,9 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         if self._manager is not None:
             return self._manager
 
-        from buttermilk import bm
         from buttermilk._core.vertex_batch import OpenAIBatchJobManager
+
+        from buttermilk import bm
 
         client = self._ensure_openai_client()
         config = bm.llms.connections[self.model]

--- a/buttermilk/processors/vertex_batch.py
+++ b/buttermilk/processors/vertex_batch.py
@@ -879,17 +879,13 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         from buttermilk import bm
 
         if self.model not in bm.llms.connections:
-            raise ValueError(
-                f"Model '{self.model}' not found in buttermilk LLM registry. "
-                f"Available models: {list(bm.llms.connections.keys())}"
-            )
+            raise ValueError(f"Model '{self.model}' not found in buttermilk LLM registry. Available models: {list(bm.llms.connections.keys())}")
 
         config = bm.llms.connections[self.model]
 
         if config.client_type.value not in ("azure", "openai"):
             raise ValueError(
-                f"OpenAIBatchProcessor requires an OpenAI or Azure model, "
-                f"but '{self.model}' has client_type='{config.client_type.value}'"
+                f"OpenAIBatchProcessor requires an OpenAI or Azure model, but '{self.model}' has client_type='{config.client_type.value}'"
             )
 
         if config.client_type.value == "azure":
@@ -918,9 +914,8 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         if self._manager is not None:
             return self._manager
 
-        from buttermilk._core.vertex_batch import OpenAIBatchJobManager
-
         from buttermilk import bm
+        from buttermilk._core.vertex_batch import OpenAIBatchJobManager
 
         client = self._ensure_openai_client()
         config = bm.llms.connections[self.model]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
   { name = "Nicolas Suzor", email = "nic@suzor.com" },
 ]
 name = "buttermilk"
-version = "0.6.1"
+dynamic = ["version"]
 description = "Modular AI research framework with async-first initialization"
 readme = "README.md"
 dependencies = [
@@ -178,8 +178,11 @@ dev = [
 
 
 [build-system]
-requires = ["setuptools>=68", "wheel"]
+requires = ["setuptools>=68", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+fallback_version = "0.6.1"
 
 [tool.setuptools]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,6 +182,7 @@ requires = ["setuptools>=68", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+fallback_version = "0.6.2"
 
 [tool.setuptools]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -182,7 +182,6 @@ requires = ["setuptools>=68", "wheel", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
-fallback_version = "0.6.1"
 
 [tool.setuptools]
 

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -15,25 +15,20 @@ def run_git(args: list[str]) -> Optional[str]:
     try:
         return subprocess.check_output(["git"] + args, stderr=subprocess.PIPE).decode().strip()
     except subprocess.CalledProcessError as e:
-        # If git describe fails, we handle this gracefully
-        if "No names found" in e.stderr.decode():
+        stderr = e.stderr.decode(errors="replace") if e.stderr is not None else ""
+        # Only treat known "no tags" / "no exact match" errors as non-fatal.
+        if "No names found" in stderr or "no tag exactly matches" in stderr:
             return None
-        # Handle detached head or other scenarios if needed
-        return None
+        # For all other git errors, re-raise so CI fails loudly instead of tagging from a bad state.
+        raise
 
 def get_latest_tag() -> Optional[str]:
     """Get the latest tag from git."""
-    try:
-        return run_git(["describe", "--tags", "--abbrev=0"])
-    except Exception:
-        return None
+    return run_git(["describe", "--tags", "--abbrev=0"])
 
 def is_current_commit_tagged() -> Optional[str]:
     """Check if the current commit is already tagged."""
-    try:
-        return run_git(["describe", "--tags", "--exact-match"])
-    except Exception:
-        return None
+    return run_git(["describe", "--tags", "--exact-match"])
 
 def bump_version(current_ver: Version, branch: str) -> str:
     """Calculate the next version based on branch."""
@@ -88,8 +83,8 @@ def main():
             print(f"Error: Latest tag '{latest_tag}' is not a valid version.")
             sys.exit(1)
     else:
-        print("No tags found. Starting at 0.0.0")
-        current_ver = Version("0.0.0")
+        print("No tags found. Starting at 0.6.1")
+        current_ver = Version("0.6.1")
 
     try:
         new_ver_str = bump_version(current_ver, branch)

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -1,14 +1,15 @@
-import os
 import argparse
+import os
 import subprocess
 import sys
 from typing import Optional
 
 try:
-    from packaging.version import Version, InvalidVersion
+    from packaging.version import InvalidVersion, Version
 except ImportError:
     print("Error: 'packaging' library not found. Install it with 'pip install packaging'.")
     sys.exit(1)
+
 
 def run_git(args: list[str]) -> Optional[str]:
     """Run a git command and return the output."""
@@ -21,6 +22,7 @@ def run_git(args: list[str]) -> Optional[str]:
         # Handle detached head or other scenarios if needed
         return None
 
+
 def get_latest_tag() -> Optional[str]:
     """Get the latest tag from git."""
     try:
@@ -28,12 +30,14 @@ def get_latest_tag() -> Optional[str]:
     except Exception:
         return None
 
+
 def is_current_commit_tagged() -> Optional[str]:
     """Check if the current commit is already tagged."""
     try:
         return run_git(["describe", "--tags", "--exact-match"])
     except Exception:
         return None
+
 
 def bump_version(current_ver: Version, branch: str) -> str:
     """Calculate the next version based on branch."""
@@ -45,6 +49,7 @@ def bump_version(current_ver: Version, branch: str) -> str:
         return f"{current_ver.major}.{current_ver.minor}.{current_ver.micro + 1}"
     else:
         raise ValueError(f"Branch '{branch}' not configured for auto-bump.")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Bump version based on branch.")
@@ -120,6 +125,7 @@ def main():
         except subprocess.CalledProcessError as e:
             print(f"Error creating/pushing tag: {e}")
             sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -1,0 +1,125 @@
+import os
+import argparse
+import subprocess
+import sys
+from typing import Optional
+
+try:
+    from packaging.version import Version, InvalidVersion
+except ImportError:
+    print("Error: 'packaging' library not found. Install it with 'pip install packaging'.")
+    sys.exit(1)
+
+def run_git(args: list[str]) -> Optional[str]:
+    """Run a git command and return the output."""
+    try:
+        return subprocess.check_output(["git"] + args, stderr=subprocess.PIPE).decode().strip()
+    except subprocess.CalledProcessError as e:
+        # If git describe fails, we handle this gracefully
+        if "No names found" in e.stderr.decode():
+            return None
+        # Handle detached head or other scenarios if needed
+        return None
+
+def get_latest_tag() -> Optional[str]:
+    """Get the latest tag from git."""
+    try:
+        return run_git(["describe", "--tags", "--abbrev=0"])
+    except Exception:
+        return None
+
+def is_current_commit_tagged() -> Optional[str]:
+    """Check if the current commit is already tagged."""
+    try:
+        return run_git(["describe", "--tags", "--exact-match"])
+    except Exception:
+        return None
+
+def bump_version(current_ver: Version, branch: str) -> str:
+    """Calculate the next version based on branch."""
+    if branch == "stable":
+        # Bump minor: 0.6.1 -> 0.7.0
+        return f"{current_ver.major}.{current_ver.minor + 1}.0"
+    elif branch == "dev":
+        # Bump patch: 0.6.1 -> 0.6.2
+        return f"{current_ver.major}.{current_ver.minor}.{current_ver.micro + 1}"
+    else:
+        raise ValueError(f"Branch '{branch}' not configured for auto-bump.")
+
+def main():
+    parser = argparse.ArgumentParser(description="Bump version based on branch.")
+    parser.add_argument("--dry-run", action="store_true", help="Print actions without executing.")
+    args = parser.parse_args()
+
+    # Determine current branch
+    branch = os.environ.get("GITHUB_REF_NAME")
+    if not branch:
+        # Fallback for local testing if not set
+        try:
+            branch = run_git(["rev-parse", "--abbrev-ref", "HEAD"])
+        except Exception:
+            branch = "unknown"
+
+    # If running locally without GITHUB_REF_NAME, allow manual override via env var
+    if not branch or branch == "HEAD":
+        branch = os.environ.get("MANUAL_BRANCH_OVERRIDE", branch)
+
+    print(f"Current branch: {branch}")
+
+    if branch not in ["dev", "stable"]:
+        print(f"Skipping version bump for branch '{branch}'. Only 'dev' and 'stable' are supported.")
+        # Exit with 0 as this is not an error condition for the workflow (just skip)
+        sys.exit(0)
+
+    # Check if already tagged
+    existing_tag = is_current_commit_tagged()
+    if existing_tag:
+        print(f"Commit is already tagged as '{existing_tag}'. Skipping bump.")
+        sys.exit(0)
+
+    latest_tag = get_latest_tag()
+    if latest_tag:
+        print(f"Latest tag found: {latest_tag}")
+        try:
+            # handle 'v' prefix
+            clean_ver = latest_tag.lstrip("v")
+            current_ver = Version(clean_ver)
+        except InvalidVersion:
+            print(f"Error: Latest tag '{latest_tag}' is not a valid version.")
+            sys.exit(1)
+    else:
+        print("No tags found. Starting at 0.0.0")
+        current_ver = Version("0.0.0")
+
+    try:
+        new_ver_str = bump_version(current_ver, branch)
+        new_tag = f"v{new_ver_str}"
+        print(f"Bumping version: {current_ver} -> {new_ver_str} ({new_tag})")
+    except ValueError as e:
+        print(str(e))
+        sys.exit(1)
+
+    if args.dry_run:
+        print(f"[DRY RUN] Would execute: git tag -a {new_tag} -m 'Auto-bump to {new_tag}'")
+        print(f"[DRY RUN] Would execute: git push origin {new_tag}")
+    else:
+        # Configure git user if running in CI
+        if os.environ.get("GITHUB_ACTIONS"):
+            try:
+                subprocess.run(["git", "config", "user.name", "github-actions[bot]"], check=True)
+                subprocess.run(["git", "config", "user.email", "github-actions[bot]@users.noreply.github.com"], check=True)
+            except subprocess.CalledProcessError as e:
+                print(f"Error configuring git user: {e}")
+                sys.exit(1)
+
+        print(f"Creating tag {new_tag}...")
+        try:
+            subprocess.run(["git", "tag", "-a", new_tag, "-m", f"Auto-bump to {new_tag}"], check=True)
+            print(f"Pushing tag {new_tag}...")
+            subprocess.run(["git", "push", "origin", new_tag], check=True)
+        except subprocess.CalledProcessError as e:
+            print(f"Error creating/pushing tag: {e}")
+            sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -1,38 +1,39 @@
-import argparse
 import os
+import argparse
 import subprocess
 import sys
 from typing import Optional
 
 try:
-    from packaging.version import InvalidVersion, Version
+    from packaging.version import Version, InvalidVersion
 except ImportError:
     print("Error: 'packaging' library not found. Install it with 'pip install packaging'.")
     sys.exit(1)
-
 
 def run_git(args: list[str]) -> Optional[str]:
     """Run a git command and return the output."""
     try:
         return subprocess.check_output(["git"] + args, stderr=subprocess.PIPE).decode().strip()
     except subprocess.CalledProcessError as e:
-        stderr = e.stderr.decode(errors="replace") if e.stderr is not None else ""
-        # Only treat known "no tags" / "no exact match" errors as non-fatal.
-        if "No names found" in stderr or "no tag exactly matches" in stderr:
+        # If git describe fails, we handle this gracefully
+        if "No names found" in e.stderr.decode():
             return None
-        # For all other git errors, re-raise so CI fails loudly instead of tagging from a bad state.
-        raise
-
+        # Handle detached head or other scenarios if needed
+        return None
 
 def get_latest_tag() -> Optional[str]:
     """Get the latest tag from git."""
-    return run_git(["describe", "--tags", "--abbrev=0"])
-
+    try:
+        return run_git(["describe", "--tags", "--abbrev=0"])
+    except Exception:
+        return None
 
 def is_current_commit_tagged() -> Optional[str]:
     """Check if the current commit is already tagged."""
-    return run_git(["describe", "--tags", "--exact-match"])
-
+    try:
+        return run_git(["describe", "--tags", "--exact-match"])
+    except Exception:
+        return None
 
 def bump_version(current_ver: Version, branch: str) -> str:
     """Calculate the next version based on branch."""
@@ -44,7 +45,6 @@ def bump_version(current_ver: Version, branch: str) -> str:
         return f"{current_ver.major}.{current_ver.minor}.{current_ver.micro + 1}"
     else:
         raise ValueError(f"Branch '{branch}' not configured for auto-bump.")
-
 
 def main():
     parser = argparse.ArgumentParser(description="Bump version based on branch.")
@@ -88,8 +88,8 @@ def main():
             print(f"Error: Latest tag '{latest_tag}' is not a valid version.")
             sys.exit(1)
     else:
-        print("No tags found. Starting at 0.6.1")
-        current_ver = Version("0.6.1")
+        print("No tags found. Starting at 0.0.0")
+        current_ver = Version("0.0.0")
 
     try:
         new_ver_str = bump_version(current_ver, branch)
@@ -120,7 +120,6 @@ def main():
         except subprocess.CalledProcessError as e:
             print(f"Error creating/pushing tag: {e}")
             sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/scripts/release/bump_version.py
+++ b/scripts/release/bump_version.py
@@ -1,14 +1,15 @@
-import os
 import argparse
+import os
 import subprocess
 import sys
 from typing import Optional
 
 try:
-    from packaging.version import Version, InvalidVersion
+    from packaging.version import InvalidVersion, Version
 except ImportError:
     print("Error: 'packaging' library not found. Install it with 'pip install packaging'.")
     sys.exit(1)
+
 
 def run_git(args: list[str]) -> Optional[str]:
     """Run a git command and return the output."""
@@ -22,13 +23,16 @@ def run_git(args: list[str]) -> Optional[str]:
         # For all other git errors, re-raise so CI fails loudly instead of tagging from a bad state.
         raise
 
+
 def get_latest_tag() -> Optional[str]:
     """Get the latest tag from git."""
     return run_git(["describe", "--tags", "--abbrev=0"])
 
+
 def is_current_commit_tagged() -> Optional[str]:
     """Check if the current commit is already tagged."""
     return run_git(["describe", "--tags", "--exact-match"])
+
 
 def bump_version(current_ver: Version, branch: str) -> str:
     """Calculate the next version based on branch."""
@@ -40,6 +44,7 @@ def bump_version(current_ver: Version, branch: str) -> str:
         return f"{current_ver.major}.{current_ver.minor}.{current_ver.micro + 1}"
     else:
         raise ValueError(f"Branch '{branch}' not configured for auto-bump.")
+
 
 def main():
     parser = argparse.ArgumentParser(description="Bump version based on branch.")
@@ -115,6 +120,7 @@ def main():
         except subprocess.CalledProcessError as e:
             print(f"Error creating/pushing tag: {e}")
             sys.exit(1)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Changes:
- Enable dynamic versioning in `pyproject.toml` using `setuptools_scm`.
- Configure `fallback_version = "0.6.1"` for fallback.
- Update `buttermilk/__init__.py` to import version from `importlib.metadata`.
- Add `scripts/release/bump_version.py` script to automate patch/minor version bumps on dev/stable.
- Add `.github/workflows/release.yml` workflow to run version bumps on push.

This setup ensures semantic versioning based on git tags and automated releases.
User should tag the initial version (e.g. `v0.6.1`) after merging to activate proper versioning.

---
*PR created automatically by Jules for task [16123848221340896630](https://jules.google.com/task/16123848221340896630) started by @nicsuzor*