### PR TITLE
Fix Vertex batch schema rejection of integer Literal enums for Gemini models

### DIFF
--- a/buttermilk/_core/json_schema.py
+++ b/buttermilk/_core/json_schema.py
@@ -154,9 +154,9 @@ def convert_enum_values_to_strings(obj: Any) -> Any:
             else:
                 new_obj[k] = convert_enum_values_to_strings(v)
 
-        # If we have an enum, ensure type is string if it was integer or number
+        # If we have an enum, ensure type is string if it was integer
         if "enum" in new_obj:
-            if new_obj.get("type") in ("integer", "number"):
+            if new_obj.get("type") == "integer":
                 new_obj["type"] = "string"
 
         return new_obj

--- a/buttermilk/_core/json_schema.py
+++ b/buttermilk/_core/json_schema.py
@@ -154,9 +154,9 @@ def convert_enum_values_to_strings(obj: Any) -> Any:
             else:
                 new_obj[k] = convert_enum_values_to_strings(v)
 
-        # If we have an enum, ensure type is string if it was integer
+        # If we have an enum, ensure type is string if it was integer or number
         if "enum" in new_obj:
-            if new_obj.get("type") == "integer":
+            if new_obj.get("type") in ("integer", "number"):
                 new_obj["type"] = "string"
 
         return new_obj

--- a/buttermilk/_core/json_schema.py
+++ b/buttermilk/_core/json_schema.py
@@ -138,6 +138,7 @@ def convert_enum_values_to_strings(obj: Any) -> Any:
 
     Vertex AI requires enum values to be strings, not integers.
     This converts any integer values in enum arrays to their string representation.
+    Also updates 'type' to 'string' if it was 'integer' when an enum is present.
 
     Args:
         obj: JSON schema node to process
@@ -146,9 +147,19 @@ def convert_enum_values_to_strings(obj: Any) -> Any:
         Processed schema with string enum values
     """
     if isinstance(obj, dict):
-        return {
-            k: ([str(v) for v in val] if k == "enum" and isinstance(val, list) else convert_enum_values_to_strings(val)) for k, val in obj.items()
-        }
+        new_obj = {}
+        for k, v in obj.items():
+            if k == "enum" and isinstance(v, list):
+                new_obj[k] = [str(item) for item in v]
+            else:
+                new_obj[k] = convert_enum_values_to_strings(v)
+
+        # If we have an enum, ensure type is string if it was integer
+        if "enum" in new_obj:
+            if new_obj.get("type") == "integer":
+                new_obj["type"] = "string"
+
+        return new_obj
     elif isinstance(obj, list):
         return [convert_enum_values_to_strings(item) for item in obj]
     return obj

--- a/buttermilk/_core/vertex_batch.py
+++ b/buttermilk/_core/vertex_batch.py
@@ -395,11 +395,11 @@ def _is_claude_model(model: str) -> bool:
     return any(pattern in model_lower for pattern in _CLAUDE_MODEL_PATTERNS)
 
 
+
 def _is_llama_model(model: str) -> bool:
     """Check if model identifier indicates a Llama/Meta model."""
     model_lower = model.lower()
     return any(pattern in model_lower for pattern in _LLAMA_MODEL_PATTERNS)
-
 
 def _is_openai_model(model: str) -> bool:
     """Check if model identifier indicates an OpenAI/GPT model."""

--- a/buttermilk/_core/vertex_batch.py
+++ b/buttermilk/_core/vertex_batch.py
@@ -395,11 +395,11 @@ def _is_claude_model(model: str) -> bool:
     return any(pattern in model_lower for pattern in _CLAUDE_MODEL_PATTERNS)
 
 
-
 def _is_llama_model(model: str) -> bool:
     """Check if model identifier indicates a Llama/Meta model."""
     model_lower = model.lower()
     return any(pattern in model_lower for pattern in _LLAMA_MODEL_PATTERNS)
+
 
 def _is_openai_model(model: str) -> bool:
     """Check if model identifier indicates an OpenAI/GPT model."""

--- a/buttermilk/_core/vertex_batch.py
+++ b/buttermilk/_core/vertex_batch.py
@@ -128,6 +128,9 @@ _CLAUDE_MODEL_PATTERNS = ("claude", "anthropic")
 # Model name patterns that indicate OpenAI/GPT models
 _OPENAI_MODEL_PATTERNS = ("gpt",)
 
+# Model name patterns that indicate Llama/Meta models
+_LLAMA_MODEL_PATTERNS = ("llama", "meta")
+
 
 class BatchMessageConverter(ABC):
     """Abstract base for converting LiteLLM messages to provider-specific batch format."""
@@ -391,6 +394,12 @@ def _is_claude_model(model: str) -> bool:
     model_lower = model.lower()
     return any(pattern in model_lower for pattern in _CLAUDE_MODEL_PATTERNS)
 
+
+
+def _is_llama_model(model: str) -> bool:
+    """Check if model identifier indicates a Llama/Meta model."""
+    model_lower = model.lower()
+    return any(pattern in model_lower for pattern in _LLAMA_MODEL_PATTERNS)
 
 def _is_openai_model(model: str) -> bool:
     """Check if model identifier indicates an OpenAI/GPT model."""

--- a/buttermilk/batch/executors/sync.py
+++ b/buttermilk/batch/executors/sync.py
@@ -19,10 +19,7 @@ class SyncBatchExecutor(BatchExecutor):
         processor.process_batch(), which expects contexts.
         """
         try:
-            contexts = [
-                ProcessingContext(session_id="sync_batch", record=record)
-                for record in records
-            ]
+            contexts = [ProcessingContext(session_id="sync_batch", record=record) for record in records]
             output_records = await processor.process_batch(contexts)
             return BatchExecutionResult(status=BatchJobStatus.COMPLETED, output_records=output_records, processed_count=len(output_records))
         except Exception as e:

--- a/buttermilk/batch/executors/sync.py
+++ b/buttermilk/batch/executors/sync.py
@@ -19,7 +19,10 @@ class SyncBatchExecutor(BatchExecutor):
         processor.process_batch(), which expects contexts.
         """
         try:
-            contexts = [ProcessingContext(session_id="sync_batch", record=record) for record in records]
+            contexts = [
+                ProcessingContext(session_id="sync_batch", record=record)
+                for record in records
+            ]
             output_records = await processor.process_batch(contexts)
             return BatchExecutionResult(status=BatchJobStatus.COMPLETED, output_records=output_records, processed_count=len(output_records))
         except Exception as e:

--- a/buttermilk/batch/executors/vertex.py
+++ b/buttermilk/batch/executors/vertex.py
@@ -45,7 +45,10 @@ class VertexBatchExecutor(BatchExecutor):
         # 2. Prepare Requests
         try:
             # Wrap bare records in minimal contexts for prepare_batch_requests
-            contexts = [ProcessingContext(session_id="vertex_batch", record=record) for record in records]
+            contexts = [
+                ProcessingContext(session_id="vertex_batch", record=record)
+                for record in records
+            ]
             # Duck typing: Assume method exists and returns list[BatchRequest]
             requests = processor.prepare_batch_requests(contexts)  # type: ignore
 

--- a/buttermilk/batch/executors/vertex.py
+++ b/buttermilk/batch/executors/vertex.py
@@ -45,10 +45,7 @@ class VertexBatchExecutor(BatchExecutor):
         # 2. Prepare Requests
         try:
             # Wrap bare records in minimal contexts for prepare_batch_requests
-            contexts = [
-                ProcessingContext(session_id="vertex_batch", record=record)
-                for record in records
-            ]
+            contexts = [ProcessingContext(session_id="vertex_batch", record=record) for record in records]
             # Duck typing: Assume method exists and returns list[BatchRequest]
             requests = processor.prepare_batch_requests(contexts)  # type: ignore
 

--- a/buttermilk/processors/vertex_batch.py
+++ b/buttermilk/processors/vertex_batch.py
@@ -74,7 +74,10 @@ class BatchLLMProcessor(BatchProcessorCore):
     """
 
     model: str = Field(..., description="Model identifier (as registered in buttermilk)")
-    template: str | None = Field(default=None, description="Jinja2 template for criteria. When used with ParameterExpansionProcessor, template comes from context.variant_params.")
+    template: str | None = Field(
+        default=None,
+        description="Jinja2 template for criteria. When used with ParameterExpansionProcessor, template comes from context.variant_params.",
+    )
     template_vars: dict[str, Any] = Field(
         default_factory=dict,
         description="Static variables for template rendering",
@@ -873,17 +876,13 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         from buttermilk import bm
 
         if self.model not in bm.llms.connections:
-            raise ValueError(
-                f"Model '{self.model}' not found in buttermilk LLM registry. "
-                f"Available models: {list(bm.llms.connections.keys())}"
-            )
+            raise ValueError(f"Model '{self.model}' not found in buttermilk LLM registry. Available models: {list(bm.llms.connections.keys())}")
 
         config = bm.llms.connections[self.model]
 
         if config.client_type.value not in ("azure", "openai"):
             raise ValueError(
-                f"OpenAIBatchProcessor requires an OpenAI or Azure model, "
-                f"but '{self.model}' has client_type='{config.client_type.value}'"
+                f"OpenAIBatchProcessor requires an OpenAI or Azure model, but '{self.model}' has client_type='{config.client_type.value}'"
             )
 
         if config.client_type.value == "azure":
@@ -912,9 +911,8 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         if self._manager is not None:
             return self._manager
 
-        from buttermilk._core.vertex_batch import OpenAIBatchJobManager
-
         from buttermilk import bm
+        from buttermilk._core.vertex_batch import OpenAIBatchJobManager
 
         client = self._ensure_openai_client()
         config = bm.llms.connections[self.model]

--- a/buttermilk/processors/vertex_batch.py
+++ b/buttermilk/processors/vertex_batch.py
@@ -74,10 +74,7 @@ class BatchLLMProcessor(BatchProcessorCore):
     """
 
     model: str = Field(..., description="Model identifier (as registered in buttermilk)")
-    template: str | None = Field(
-        default=None,
-        description="Jinja2 template for criteria. When used with ParameterExpansionProcessor, template comes from context.variant_params.",
-    )
+    template: str | None = Field(default=None, description="Jinja2 template for criteria. When used with ParameterExpansionProcessor, template comes from context.variant_params.")
     template_vars: dict[str, Any] = Field(
         default_factory=dict,
         description="Static variables for template rendering",
@@ -876,13 +873,17 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         from buttermilk import bm
 
         if self.model not in bm.llms.connections:
-            raise ValueError(f"Model '{self.model}' not found in buttermilk LLM registry. Available models: {list(bm.llms.connections.keys())}")
+            raise ValueError(
+                f"Model '{self.model}' not found in buttermilk LLM registry. "
+                f"Available models: {list(bm.llms.connections.keys())}"
+            )
 
         config = bm.llms.connections[self.model]
 
         if config.client_type.value not in ("azure", "openai"):
             raise ValueError(
-                f"OpenAIBatchProcessor requires an OpenAI or Azure model, but '{self.model}' has client_type='{config.client_type.value}'"
+                f"OpenAIBatchProcessor requires an OpenAI or Azure model, "
+                f"but '{self.model}' has client_type='{config.client_type.value}'"
             )
 
         if config.client_type.value == "azure":
@@ -911,8 +912,9 @@ class OpenAIBatchProcessor(BatchLLMProcessor):
         if self._manager is not None:
             return self._manager
 
-        from buttermilk import bm
         from buttermilk._core.vertex_batch import OpenAIBatchJobManager
+
+        from buttermilk import bm
 
         client = self._ensure_openai_client()
         config = bm.llms.connections[self.model]

--- a/tests/demo/test_vertex_demo.py
+++ b/tests/demo/test_vertex_demo.py
@@ -182,7 +182,6 @@ class TestVertexBatchProcessorDemo:
         # ==== PROCESSING ====
         print("\n🔄 Processing batch...")
         from buttermilk._core.processing_context import ProcessingContext
-
         ctx = ProcessingContext(session_id="demo", record=record)
         results = await processor.process_batch([ctx])
 

--- a/tests/demo/test_vertex_demo.py
+++ b/tests/demo/test_vertex_demo.py
@@ -182,6 +182,7 @@ class TestVertexBatchProcessorDemo:
         # ==== PROCESSING ====
         print("\n🔄 Processing batch...")
         from buttermilk._core.processing_context import ProcessingContext
+
         ctx = ProcessingContext(session_id="demo", record=record)
         results = await processor.process_batch([ctx])
 

--- a/tests/processors/test_vertex_batch.py
+++ b/tests/processors/test_vertex_batch.py
@@ -777,7 +777,6 @@ class TestJsonSchemaUtilities:
         result = convert_enum_values_to_strings(schema)
 
         assert result["properties"]["nested"]["properties"]["level"]["enum"] == ["1", "2", "3"]
-        assert result["properties"]["nested"]["properties"]["level"]["type"] == "string"
 
     def test_prepare_schema_for_vertex_gemini(self):
         """prepare_schema_for_vertex with is_gemini should convert enums."""

--- a/tests/processors/test_vertex_batch.py
+++ b/tests/processors/test_vertex_batch.py
@@ -777,6 +777,7 @@ class TestJsonSchemaUtilities:
         result = convert_enum_values_to_strings(schema)
 
         assert result["properties"]["nested"]["properties"]["level"]["enum"] == ["1", "2", "3"]
+        assert result["properties"]["nested"]["properties"]["level"]["type"] == "string"
 
     def test_prepare_schema_for_vertex_gemini(self):
         """prepare_schema_for_vertex with is_gemini should convert enums."""

--- a/tests/processors/test_vertex_batch.py
+++ b/tests/processors/test_vertex_batch.py
@@ -755,6 +755,7 @@ class TestJsonSchemaUtilities:
         result = convert_enum_values_to_strings(schema)
 
         assert result["properties"]["status"]["enum"] == ["0", "1", "2"]
+        assert result["properties"]["status"]["type"] == "string"
         assert result["properties"]["name"]["type"] == "string"
 
     def test_convert_enum_nested(self):

--- a/tests/test_unified_processor.py
+++ b/tests/test_unified_processor.py
@@ -1135,10 +1135,7 @@ class TestBatchProcessor:
         # Batch processor: tags records with "batch"
         class MockBatchProcessor(ObservabilityMixin):
             async def process_batch(self, contexts: list[ProcessingContext]) -> list[BaseRecord]:
-                return [
-                    ctx.record.model_copy(update={"metadata": {**ctx.record.metadata, "source": "batch"}})
-                    for ctx in contexts
-                ]
+                return [ctx.record.model_copy(update={"metadata": {**ctx.record.metadata, "source": "batch"}}) for ctx in contexts]
 
         # Live processor: tags records with "live"
         class MockLiveProcessor(ProcessorCore):
@@ -1185,7 +1182,6 @@ class TestBatchProcessor:
     async def test_batch_accumulator_live_processor_error_continues(self):
         """Verify live processor errors don't block other processors in fan-out."""
         from buttermilk._core.processor_core import ObservabilityMixin
-        from buttermilk.pipeline import RecordBufferedException
         from buttermilk.processors.batch_accumulator import BatchAccumulator
 
         # This live processor always fails

--- a/tests/test_unified_processor.py
+++ b/tests/test_unified_processor.py
@@ -1135,7 +1135,10 @@ class TestBatchProcessor:
         # Batch processor: tags records with "batch"
         class MockBatchProcessor(ObservabilityMixin):
             async def process_batch(self, contexts: list[ProcessingContext]) -> list[BaseRecord]:
-                return [ctx.record.model_copy(update={"metadata": {**ctx.record.metadata, "source": "batch"}}) for ctx in contexts]
+                return [
+                    ctx.record.model_copy(update={"metadata": {**ctx.record.metadata, "source": "batch"}})
+                    for ctx in contexts
+                ]
 
         # Live processor: tags records with "live"
         class MockLiveProcessor(ProcessorCore):
@@ -1182,6 +1185,7 @@ class TestBatchProcessor:
     async def test_batch_accumulator_live_processor_error_continues(self):
         """Verify live processor errors don't block other processors in fan-out."""
         from buttermilk._core.processor_core import ObservabilityMixin
+        from buttermilk.pipeline import RecordBufferedException
         from buttermilk.processors.batch_accumulator import BatchAccumulator
 
         # This live processor always fails

--- a/tests/test_vertex_executor.py
+++ b/tests/test_vertex_executor.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from google.genai.types import BatchJob, JobState
 
+from buttermilk._core.processing_context import ProcessingContext
 from buttermilk._core.processor_core import BatchProcessorCore
 from buttermilk._core.types import BaseRecord
 from buttermilk.batch.executors.vertex import BatchExecutionResult, BatchJobStatus, VertexBatchExecutor

--- a/tests/test_vertex_executor.py
+++ b/tests/test_vertex_executor.py
@@ -3,7 +3,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from google.genai.types import BatchJob, JobState
 
-from buttermilk._core.processing_context import ProcessingContext
 from buttermilk._core.processor_core import BatchProcessorCore
 from buttermilk._core.types import BaseRecord
 from buttermilk.batch.executors.vertex import BatchExecutionResult, BatchJobStatus, VertexBatchExecutor


### PR DESCRIPTION
Resolves issue #355 by implementing `_is_llama_model` to fix model identification and updating schema conversion to coerce integer enums (and their type) to strings for Gemini models. This ensures valid JSON schema for Vertex AI which requires string enums.

---
*PR created automatically by Jules for task [17059973132316876804](https://jules.google.com/task/17059973132316876804) started by @nicsuzor*