### PR TITLE
Mark slow tests (>10s) with @pytest.mark.slow

### DIFF
--- a/tests/agents/test_variants.py
+++ b/tests/agents/test_variants.py
@@ -278,6 +278,7 @@ def test_empty_variants(base_variant_config):
     assert config.parameters == {"base_param": "base_value"}
 
 
+@pytest.mark.slow
 def test_agent_not_found(base_variant_config):
     """Test that ValueError is raised if agent_obj is not found."""
     config_data = {**base_variant_config, "agent_obj": "NonExistentAgent"}
@@ -347,6 +348,6 @@ def test_step_config_get_configs_structure_and_ids(
         all_config_ids.append(agent_config.agent_id)
 
     # Check the core requirement: IDs must be unique across all returned configs
-    assert len(all_config_ids) == len(set(all_config_ids)), (
-        f"AgentConfig.agent_id values are not unique across returned configs. Found IDs: {all_config_ids}"
-    )
+    assert len(all_config_ids) == len(
+        set(all_config_ids)
+    ), f"AgentConfig.agent_id values are not unique across returned configs. Found IDs: {all_config_ids}"

--- a/tests/data/test_records_openaimessages.py
+++ b/tests/data/test_records_openaimessages.py
@@ -7,6 +7,7 @@ from buttermilk.utils.media import download_and_convert
 pytestmark = pytest.mark.anyio
 
 
+@pytest.mark.slow
 @pytest.mark.anyio
 async def test_record_remote_load(multimodal_record):
     assert multimodal_record

--- a/tests/investigations/test_zotero_pdf_skip_simple.py
+++ b/tests/investigations/test_zotero_pdf_skip_simple.py
@@ -9,6 +9,7 @@ import pytest
 from buttermilk._core.types import Record
 
 
+@pytest.mark.slow
 @pytest.mark.anyio
 async def test_no_pdf_download_when_fulltext_exists():
     """Test that PDF is NOT downloaded when Zotero provides fulltext."""

--- a/tests/test_debug_agent.py
+++ b/tests/test_debug_agent.py
@@ -7,6 +7,7 @@ import pytest
 from buttermilk.debug.debug_agent import DebugAgent
 
 
+@pytest.mark.slow
 @pytest.mark.anyio
 async def test_debug_agent():
     """Test the debug agent tools."""

--- a/tests/unit/test_litellm_wrapper.py
+++ b/tests/unit/test_litellm_wrapper.py
@@ -96,6 +96,7 @@ class TestMessageFormatConversion:
         assert result.cached is False
 
 
+@pytest.mark.slow
 @pytest.mark.anyio
 class TestLiteLLMWrapperCreate:
     """Test LiteLLMWrapper.create() method."""
@@ -199,6 +200,7 @@ class TestLiteLLMWrapperCreate:
             assert mock_acompletion.call_count == 2  # Initial + 1 retry
 
 
+@pytest.mark.slow
 @pytest.mark.anyio
 class TestLiteLLMWrapperStructuredOutput:
     """Test structured output with LiteLLMWrapper."""

--- a/tests/unit/test_llms_pricing.py
+++ b/tests/unit/test_llms_pricing.py
@@ -240,6 +240,7 @@ class TestLiteLLMIntegration:
             # Some models may not be in litellm's pricing database yet - that's OK
             pytest.skip(f"Model {resolved_name} not in litellm pricing: {e}")
 
+    @pytest.mark.slow
     def test_bad_model_names_should_fail(self):
         """Test that malformed model names properly fail with litellm."""
         from litellm.cost_calculator import cost_per_token

--- a/tests/utils/test_text_quality.py
+++ b/tests/utils/test_text_quality.py
@@ -89,6 +89,7 @@ def test_analyze_document_quality_aggregates_chunks():
     assert result["corruption_rate"] == 25.0  # 1 out of 4 = 25%
 
 
+@pytest.mark.slow
 def test_analyze_document_quality_highly_corrupt_document():
     """Test analyze_document_quality() with 95%+ corrupt document."""
     # Arrange: Create corrupt chunk with 25 CID patterns (above 20 threshold)
@@ -183,9 +184,9 @@ def test_is_document_corrupt_threshold(corrupted_chunk_count, total_chunks, thre
     # Assert - verify corruption detection logic
     expected_rate = (corrupted_chunk_count / total_chunks) * 100
     assert result["corruption_rate"] == pytest.approx(expected_rate, rel=0.01), f"Corruption rate should be {expected_rate}%"
-    assert result["is_corrupt"] is expected_corrupt, (
-        f"With {expected_rate}% corruption and {threshold}% threshold, is_corrupt should be {expected_corrupt}"
-    )
+    assert (
+        result["is_corrupt"] is expected_corrupt
+    ), f"With {expected_rate}% corruption and {threshold}% threshold, is_corrupt should be {expected_corrupt}"
     assert result["corrupted_chunks"] == corrupted_chunk_count
     assert result["total_chunks"] == total_chunks
     assert result["threshold"] == threshold


### PR DESCRIPTION
## Summary
- Identified tests taking >10s via `pytest --durations=0` and marked them with `@pytest.mark.slow`
- Reduces fast test suite runtime from ~3.5min to ~2.5min (~30% faster)
- 7 test files updated (test_tmdb.py and test_embedding_processor.py have pre-existing lint issues and need separate cleanup)

## Test plan
- [x] Verified `pytest -m "slow" --collect-only` shows newly marked tests
- [x] Verified fast suite (`-m "not slow"`) runs ~60s faster
- [x] No functional changes to test logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)