### PR TITLE
Fix LLMProcessor variant_params not merged into template vars

### DIFF
--- a/buttermilk/processors/unified_processors.py
+++ b/buttermilk/processors/unified_processors.py
@@ -129,6 +129,11 @@ class LLMProcessor(ProcessorCore):
             # For non-Pydantic records
             template_vars = {"record": context.record}
 
+        # Merge variant_params into template vars for template rendering
+        # (e.g., criteria from ParameterExpansionProcessor)
+        if context.variant_params:
+            template_vars.update(context.variant_params)
+
         # Create LLMCore with resolved params if they differ from defaults
         llm_core = self._llm_core
         if resolved_model != self.model or resolved_template != self.template:


### PR DESCRIPTION
## Summary

- Fixes #366: `LLMProcessor._process_record()` now merges `context.variant_params` into `template_vars` before passing to `LLMCore.process_with_llm()`
- Matches the existing pattern in `VertexBatchProcessor` (vertex_batch.py:371-373)
- Without this fix, template variables like `criteria` from `ParameterExpansionProcessor` are silently dropped, causing `"unfilled parameters"` errors

## Test plan

- [x] All 53 existing LLMProcessor/unified_processor tests pass
- [ ] Verify with a pipeline config using `ParameterExpansionProcessor` → `LLMProcessor` with a template that expects `{{ criteria }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)